### PR TITLE
fix: align preference type module boundaries

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -65,6 +65,7 @@ The client never calls TMDB directly. `lib/tmdb.ts` → `/api/tmdb/*` → `api.t
 
 - Google Identity Services (GSI) script loaded imperatively in `pages/settings.tsx`; credential exchanged via Firebase `signInWithCredential`.
 - `lib/AuthContext.tsx` subscribes to `onAuthStateChanged`; exposes `user`, `preferences`, `signOut`, `updatePreferences`, `refreshPreferences`.
+- `lib/preferences.ts` owns the `FavoriteService` and `UserPreferences` types plus pure normalization and selection helpers; `lib/firestore.ts` imports that model and remains a persistence adapter rather than re-exporting it.
 - Firestore stores `users/{uid}` → `{ favoriteCountries: string[], favoriteServices: FavoriteService[], darkMode: boolean }` via `setDoc(..., { merge: true })` with a 10s timeout wrapper. Note the **named** Firestore database: `getFirestore(app, "watchatlaspreference")`.
 - `favoriteServices` is a flat global set of TMDB provider IDs (`{ id, name, logoPath }`), applied across every favorite country rather than mapped per country. `normalizePreferences` in `lib/preferences.ts` hardens whatever Firestore returns before the app sees it.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -40,7 +40,7 @@ components/
 lib/
   tmdb.ts              # Client fetch wrappers (tmdbService)
   firebase.ts / firestore.ts / AuthContext.tsx
-  preferences.ts       # Firebase-free preference logic (firestore.ts re-exports it)
+  preferences.ts       # Firebase-free preference logic
   providerCatalog.ts   # parseRegions, mergeProviderCatalog — pure, zero imports
   discoverMerge.ts     # parseProviderIds, mergeDiscoverResults — pure, zero imports
   providerPreferences.ts  # splitProvidersByPreference, buildProviderDisplayTiers

--- a/lib/AuthContext.tsx
+++ b/lib/AuthContext.tsx
@@ -1,7 +1,8 @@
 import { createContext, useContext, useEffect, useRef, useState, ReactNode } from "react";
 import { User, onAuthStateChanged, signOut as firebaseSignOut } from "firebase/auth";
 import { auth } from "./firebase";
-import { loadUserPreferences, saveUserPreferences, UserPreferences } from "./firestore";
+import { loadUserPreferences, saveUserPreferences } from "./firestore";
+import type { UserPreferences } from "./preferences";
 
 interface AuthContextType {
   user: User | null;

--- a/lib/firestore.ts
+++ b/lib/firestore.ts
@@ -4,9 +4,6 @@ import { doc, setDoc, getDoc } from "firebase/firestore";
 import { normalizePreferences } from "./preferences";
 import type { UserPreferences } from "./preferences";
 
-export { normalizePreferences } from "./preferences";
-export type { FavoriteService, UserPreferences } from "./preferences";
-
 // Helper function to add timeout to promises
 function withTimeout<T>(promise: Promise<T>, ms: number, operation: string): Promise<T> {
   return new Promise((resolve, reject) => {

--- a/lib/providerPreferences.ts
+++ b/lib/providerPreferences.ts
@@ -1,4 +1,4 @@
-import type { FavoriteService } from "./firestore";
+import type { FavoriteService } from "./preferences";
 
 export type WatchProvider = {
   provider_id: number;

--- a/tests/providerPreferences.test.ts
+++ b/tests/providerPreferences.test.ts
@@ -5,7 +5,7 @@ import {
   buildProviderDisplayTiers,
   collectStreamingProviders,
 } from "../lib/providerPreferences";
-import type { FavoriteService } from "../lib/firestore";
+import type { FavoriteService } from "../lib/preferences";
 
 const provider = (id: number, name: string) => ({
   provider_id: id,


### PR DESCRIPTION
## Summary\n- keep FavoriteService and UserPreferences canonical in lib/preferences.ts\n- update pure provider logic and tests to import FavoriteService directly from preferences\n- keep lib/firestore.ts focused on persistence instead of re-exporting preference models\n\n## Verification\n- npm test: 102 passing\n- tsc --noEmit --incremental false\n- npm run build\n\nCloses #44