### PR TITLE
fix: make provider catalog metadata deterministic

### DIFF
--- a/lib/providerCatalog.ts
+++ b/lib/providerCatalog.ts
@@ -58,15 +58,17 @@ export function mergeProviderCatalog(
 
       const existing = byId.get(provider.provider_id);
       if (existing) {
-        // The same provider appears in both the movie and TV catalogues; union
-        // their regions and take the best priority across both, so `regions`
-        // and `displayPriority` do not depend on which catalogue was processed
-        // first. `name` and `logoPath` are NOT merged — they keep the values
-        // from whichever catalogue was seen first, so a provider whose
-        // `logo_path` is null in one response and populated in the other still
-        // renders order-dependently. Tracked separately; `pickCanonical` in
-        // lib/providerPreferences.ts is the order-independent rule to follow
-        // when fixing it.
+        // The same provider appears in both the movie and TV catalogues. Merge
+        // every field with commutative rules so response order cannot change
+        // the result: union regions, take the best priority, and choose stable
+        // canonical metadata while preferring a populated logo.
+        const metadata = pickCanonicalMetadata(existing, {
+          name: provider.provider_name,
+          logoPath: provider.logo_path ?? "",
+        });
+
+        existing.name = metadata.name;
+        existing.logoPath = metadata.logoPath;
         existing.regions = [...new Set([...existing.regions, ...available])];
         existing.displayPriority = Math.min(existing.displayPriority, priorityFor(provider, available));
         continue;
@@ -85,6 +87,20 @@ export function mergeProviderCatalog(
   return [...byId.values()].sort(
     (a, b) => a.displayPriority - b.displayPriority || a.name.localeCompare(b.name)
   );
+}
+
+type ProviderMetadata = Pick<CatalogProvider, "name" | "logoPath">;
+
+/**
+ * Picks one metadata record whole using a total order. Pairwise selection is
+ * therefore commutative and associative, which keeps the result stable even if
+ * TMDB returns duplicate providers in a different catalogue order.
+ */
+function pickCanonicalMetadata(a: ProviderMetadata, b: ProviderMetadata): ProviderMetadata {
+  if (Boolean(a.logoPath) !== Boolean(b.logoPath)) return a.logoPath ? a : b;
+  if (a.name !== b.name) return a.name < b.name ? a : b;
+  if (a.logoPath !== b.logoPath) return a.logoPath < b.logoPath ? a : b;
+  return a;
 }
 
 function regionsFor(provider: TmdbProvider, regions: string[]): string[] {

--- a/tests/providerCatalog.test.ts
+++ b/tests/providerCatalog.test.ts
@@ -122,4 +122,39 @@ describe("mergeProviderCatalog", () => {
     assert.deepEqual(movieFirst[0].regions.sort(), ["GB", "US"]);
     assert.deepEqual(tvFirst[0].regions.sort(), ["GB", "US"]);
   });
+
+  test("prefers populated duplicate metadata regardless of catalogue order", () => {
+    const withoutLogo = { ...netflix, logo_path: null };
+    const withLogo = { ...netflix, logo_path: "/netflix-tv.jpg" };
+
+    const withoutLogoFirst = mergeProviderCatalog(
+      [{ results: [withoutLogo] }, { results: [withLogo] }],
+      ["US"]
+    );
+    const withLogoFirst = mergeProviderCatalog(
+      [{ results: [withLogo] }, { results: [withoutLogo] }],
+      ["US"]
+    );
+
+    assert.deepEqual(withoutLogoFirst, withLogoFirst);
+    assert.equal(withoutLogoFirst[0].logoPath, "/netflix-tv.jpg");
+  });
+
+  test("uses stable tie-breakers for conflicting names and populated logos", () => {
+    const alpha = { ...netflix, provider_name: "Alpha", logo_path: "/z.jpg" };
+    const beta = { ...netflix, provider_name: "Beta", logo_path: "/a.jpg" };
+    const logoA = { ...netflix, provider_name: "Netflix", logo_path: "/a.jpg" };
+    const logoZ = { ...netflix, provider_name: "Netflix", logo_path: "/z.jpg" };
+
+    const nameForward = mergeProviderCatalog([{ results: [alpha] }, { results: [beta] }], ["US"]);
+    const nameReverse = mergeProviderCatalog([{ results: [beta] }, { results: [alpha] }], ["US"]);
+    const logoForward = mergeProviderCatalog([{ results: [logoZ] }, { results: [logoA] }], ["US"]);
+    const logoReverse = mergeProviderCatalog([{ results: [logoA] }, { results: [logoZ] }], ["US"]);
+
+    assert.deepEqual(nameForward, nameReverse);
+    assert.equal(nameForward[0].name, "Alpha");
+    assert.equal(nameForward[0].logoPath, "/z.jpg");
+    assert.deepEqual(logoForward, logoReverse);
+    assert.equal(logoForward[0].logoPath, "/a.jpg");
+  });
 });


### PR DESCRIPTION
Updates PR #52 by addressing its actionable reliability review finding.

- Prefer populated provider logos.
- Use stable name and logo tie-breakers.
- Preserve region union and best display priority.
- Add forward/reverse-order regression coverage.

Tracked by #53. The full suite passes 104/104 and TypeScript type-checking passes.