### PR TITLE
Fix PR #34 review findings

### DIFF
--- a/lib/AuthContext.tsx
+++ b/lib/AuthContext.tsx
@@ -2,7 +2,7 @@ import { createContext, useContext, useEffect, useRef, useState, ReactNode } fro
 import { User, onAuthStateChanged, signOut as firebaseSignOut } from "firebase/auth";
 import { auth } from "./firebase";
 import { loadUserPreferences, saveUserPreferences } from "./firestore";
-import type { UserPreferences } from "./preferences";
+import type { PreferencesLoadStatus, UserPreferences } from "./preferences";
 
 interface AuthContextType {
   user: User | null;
@@ -12,6 +12,7 @@ interface AuthContextType {
   // resolves, so consumers cannot assume the two are in step. Anything that
   // copies preferences into its own state must check this first.
   preferencesUid: string | null;
+  preferencesStatus: PreferencesLoadStatus;
   loading: boolean;
   signOut: () => Promise<void>;
   updatePreferences: (prefs: Partial<UserPreferences>) => Promise<void>;
@@ -24,6 +25,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const [user, setUser] = useState<User | null>(null);
   const [preferences, setPreferences] = useState<UserPreferences | null>(null);
   const [preferencesUid, setPreferencesUid] = useState<string | null>(null);
+  const [preferencesStatus, setPreferencesStatus] = useState<PreferencesLoadStatus>("idle");
   const [loading, setLoading] = useState(true);
 
   // The uid of the most recent auth event. Two sign-ins in quick succession can
@@ -57,20 +59,31 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       setPreferencesUid(null);
 
       if (firebaseUser) {
-        const prefs = await loadUserPreferences(firebaseUser.uid);
+        setPreferencesStatus("loading");
+        try {
+          const prefs = await loadUserPreferences(firebaseUser.uid);
 
-        // A newer auth event landed while this load was in flight — its result
-        // is the current one, so discard ours rather than clobbering it.
-        if (latestUid.current !== firebaseUser.uid) return;
+          // A newer auth event landed while this load was in flight — its result
+          // is the current one, so discard ours rather than clobbering it.
+          if (latestUid.current !== firebaseUser.uid) return;
 
-        setPreferences(prefs);
-        setPreferencesUid(firebaseUser.uid);
+          setPreferences(prefs);
+          setPreferencesUid(firebaseUser.uid);
+          setPreferencesStatus("ready");
 
-        // Apply dark mode preference from user prefs (default to true/dark)
-        const darkMode = prefs?.darkMode ?? true;
-        applyTheme(darkMode);
-        localStorage.setItem("darkMode", String(darkMode));
+          // Apply dark mode preference from user prefs (default to true/dark)
+          applyTheme(prefs.darkMode);
+          localStorage.setItem("darkMode", String(prefs.darkMode));
+        } catch {
+          if (latestUid.current !== firebaseUser.uid) return;
+          // Keep the failed read visibly distinct from a valid new account's
+          // empty defaults. Consumers must not enable persistence in this state.
+          setPreferences(null);
+          setPreferencesUid(null);
+          setPreferencesStatus("error");
+        }
       } else {
+        setPreferencesStatus("idle");
         // For non-logged-in users, use localStorage or default to dark
         const savedTheme = localStorage.getItem("darkMode");
         applyTheme(savedTheme === null ? true : savedTheme === "true");
@@ -89,6 +102,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     setUser(null);
     setPreferences(null);
     setPreferencesUid(null);
+    setPreferencesStatus("idle");
   };
 
   const updatePreferences = async (prefs: Partial<UserPreferences>) => {
@@ -119,24 +133,27 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     // the previous identity's preferences into a signed-out context.
     if (latestUid.current !== user.uid) return;
 
-    // Update local state
-    setPreferences((prev) => ({
-      favoriteCountries: prev?.favoriteCountries ?? [],
-      darkMode: prev?.darkMode ?? true,
-      favoriteServices: prev?.favoriteServices ?? [],
-      ...prefs,
-    }));
-    // The merged object is this user's now, whether or not the load that would
-    // have claimed it has resolved.
-    setPreferencesUid(user.uid);
+    // A dark-mode write can happen while the initial read is still pending.
+    // Persist that single field, but do not manufacture an empty preference
+    // object or claim readiness before the authoritative read completes.
+    if (preferencesStatus === "ready" && preferencesUid === user.uid) {
+      setPreferences((prev) => prev ? { ...prev, ...prefs } : prev);
+    }
   };
 
   const refreshPreferences = async () => {
     if (!user) return;
-    const prefs = await loadUserPreferences(user.uid);
-    if (latestUid.current !== user.uid) return;
-    setPreferences(prefs);
-    setPreferencesUid(user.uid);
+    setPreferencesStatus("loading");
+    try {
+      const prefs = await loadUserPreferences(user.uid);
+      if (latestUid.current !== user.uid) return;
+      setPreferences(prefs);
+      setPreferencesUid(user.uid);
+      setPreferencesStatus("ready");
+    } catch {
+      if (latestUid.current !== user.uid) return;
+      setPreferencesStatus("error");
+    }
   };
 
   return (
@@ -145,6 +162,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         user,
         preferences,
         preferencesUid,
+        preferencesStatus,
         loading,
         signOut,
         updatePreferences,

--- a/lib/discoverMerge.ts
+++ b/lib/discoverMerge.ts
@@ -14,6 +14,9 @@ export type DiscoverItem = {
 /** TMDB is queried once per region per media type, so this bounds the fan-out at 10 calls. */
 export const MAX_DISCOVER_REGIONS = 5;
 
+/** Keeps the public discover route's provider fan-out and cache-key surface bounded. */
+export const MAX_DISCOVER_PROVIDERS = 50;
+
 export const MAX_DISCOVER_RESULTS = 20;
 
 const POSITIVE_INT = /^\d+$/;
@@ -30,9 +33,12 @@ export function parseProviderIds(raw: unknown): number[] | null {
   if (parts.some((part) => !POSITIVE_INT.test(part))) return null;
 
   const ids = parts.map(Number);
-  if (ids.some((id) => !Number.isSafeInteger(id))) return null;
+  if (ids.some((id) => !Number.isSafeInteger(id) || id <= 0)) return null;
 
-  return [...new Set(ids)];
+  const canonical = [...new Set(ids)].sort((a, b) => a - b);
+  if (canonical.length > MAX_DISCOVER_PROVIDERS) return null;
+
+  return canonical;
 }
 
 /**

--- a/lib/firestore.ts
+++ b/lib/firestore.ts
@@ -44,7 +44,7 @@ export async function saveUserPreferences(
 // Load preferences with sensible defaults if fields are missing
 export async function loadUserPreferences(
   uid: string
-): Promise<UserPreferences | null> {
+): Promise<UserPreferences> {
   try {
     const userRef = doc(db, "users", uid);
     const snapshot = await withTimeout(
@@ -57,9 +57,11 @@ export async function loadUserPreferences(
       return normalizePreferences(snapshot.data());
     }
 
-    return null;
+    // A missing document is a valid new account, not a failed read. Publish
+    // explicit defaults so consumers can safely distinguish it from an error.
+    return normalizePreferences({});
   } catch (error) {
     console.error("Error loading preferences:", error);
-    return null;
+    throw error;
   }
 }

--- a/lib/preferences.ts
+++ b/lib/preferences.ts
@@ -4,7 +4,9 @@
 // Firebase import. lib/firestore.ts imports lib/firebase.ts, which calls
 // initializeApp()/getAuth() at module load — importing that module just to
 // test normalizePreferences() boots live Firebase and throws without env
-// vars. Keeping this file dependency-free lets it be unit tested standalone.
+// vars. Keeping this file free of Firebase lets it be unit tested standalone.
+
+import { MAX_DISCOVER_PROVIDERS } from "./discoverMerge";
 
 export type FavoriteService = {
   id: number;
@@ -17,6 +19,8 @@ export type UserPreferences = {
   darkMode: boolean;
   favoriteServices: FavoriteService[];
 };
+
+export type PreferencesLoadStatus = "idle" | "loading" | "ready" | "error";
 
 // Firestore documents are untrusted input: a partial write or an older client
 // can leave any field missing or the wrong shape. Normalizing in one place keeps
@@ -72,6 +76,22 @@ export function resolveHydrationAction(input: {
   return "hydrate";
 }
 
+// A signed-in identity is not enough to make Save safe. The editable copy may
+// only be persisted after that identity's Firestore read completed
+// successfully; otherwise its initial empty arrays could overwrite stored
+// selections after a slow or failed load.
+export function canSavePreferences(input: {
+  userUid: string | null;
+  preferencesUid: string | null;
+  status: PreferencesLoadStatus;
+}): boolean {
+  return (
+    input.status === "ready" &&
+    input.userUid !== null &&
+    input.preferencesUid === input.userUid
+  );
+}
+
 // Selection helpers. ServicePicker is a controlled component, so the list of
 // chosen services lives in the parent page; keeping the transitions pure here
 // means they can be unit tested without rendering React.
@@ -100,7 +120,12 @@ export function resolveActiveCountry(countries: string[], current: string | null
 function isFavoriteService(value: unknown): value is { id: number; name: string; logoPath?: unknown } {
   if (typeof value !== "object" || value === null) return false;
   const candidate = value as Record<string, unknown>;
-  return Number.isFinite(candidate.id) && typeof candidate.name === "string";
+  return (
+    typeof candidate.id === "number" &&
+    Number.isSafeInteger(candidate.id) &&
+    candidate.id > 0 &&
+    typeof candidate.name === "string"
+  );
 }
 
 // Eligibility + query construction for the "On My Services" home row. Pure so
@@ -131,8 +156,16 @@ export function buildDiscoverQuery(
 
   if (countries.length === 0 || services.length === 0) return null;
 
+  const providerIds = [...new Set(
+    services
+      .map((service) => service.id)
+      .filter((id) => Number.isSafeInteger(id) && id > 0)
+  )].sort((a, b) => a - b);
+
+  if (providerIds.length === 0 || providerIds.length > MAX_DISCOVER_PROVIDERS) return null;
+
   const regions = encodeURIComponent(countries.join(","));
-  const providers = encodeURIComponent(services.map((service) => service.id).join("|"));
+  const providers = encodeURIComponent(providerIds.join("|"));
 
   return `/api/tmdb/discover?regions=${regions}&providers=${providers}`;
 }

--- a/pages/api/tmdb/discover.ts
+++ b/pages/api/tmdb/discover.ts
@@ -34,6 +34,17 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     });
   }
 
+  // Canonical input collapses equivalent provider sets to one cache key. The
+  // client emits this sorted, deduped form; rejecting variants prevents public
+  // callers from bypassing the CDN with permutations that trigger identical
+  // upstream work.
+  const providerParam = providers.join("|");
+  if (req.query.providers !== providerParam) {
+    return res.status(400).json({
+      error: "providers must be sorted, unique positive TMDB provider ids",
+    });
+  }
+
   const apiKey = process.env.TMDB_API_KEY;
 
   if (!apiKey) {
@@ -42,11 +53,10 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
   // Bound the fan-out; the response reports what was actually queried so the UI
   // can be honest about coverage rather than implying it searched everywhere.
-  const regionsUsed = allRegions.slice(0, MAX_DISCOVER_REGIONS);
-  const providerParam = providers.join("|");
+  const requestedRegions = allRegions.slice(0, MAX_DISCOVER_REGIONS);
 
-  const requests = regionsUsed.flatMap((region) =>
-    MEDIA_TYPES.map(async (mediaType): Promise<DiscoverItem[]> => {
+  const requests = requestedRegions.flatMap((region) =>
+    MEDIA_TYPES.map(async (mediaType): Promise<{ region: string; items: DiscoverItem[] }> => {
       const url =
         `${API_BASE}/discover/${mediaType}` +
         `?api_key=${apiKey}` +
@@ -59,22 +69,26 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       if (!response.ok) throw new Error(`discover ${mediaType} ${region} responded ${response.status}`);
 
       const data = await response.json();
-      return (data.results ?? []).map((item: any) => ({
-        id: item.id,
-        media_type: mediaType,
-        title: item.title,
-        name: item.name,
-        poster_path: item.poster_path,
-        popularity: item.popularity,
-        release_date: item.release_date,
-        first_air_date: item.first_air_date,
-      }));
+      return {
+        region,
+        items: (data.results ?? []).map((item: any) => ({
+          id: item.id,
+          media_type: mediaType,
+          title: item.title,
+          name: item.name,
+          poster_path: item.poster_path,
+          popularity: item.popularity,
+          release_date: item.release_date,
+          first_air_date: item.first_air_date,
+        })),
+      };
     })
   );
 
   const settled = await Promise.allSettled(requests);
   const succeeded = settled.filter(
-    (result): result is PromiseFulfilledResult<DiscoverItem[]> => result.status === "fulfilled"
+    (result): result is PromiseFulfilledResult<{ region: string; items: DiscoverItem[] }> =>
+      result.status === "fulfilled"
   );
 
   // Only a total failure is an error; otherwise merge whatever came back.
@@ -83,8 +97,14 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     return res.status(502).json({ error: "Failed to fetch discover results" });
   }
 
-  const results = mergeDiscoverResults(succeeded.map((result) => result.value));
+  const results = mergeDiscoverResults(succeeded.map((result) => result.value.items));
+  const successfulRegionSet = new Set(succeeded.map((result) => result.value.region));
+  const regionsUsed = requestedRegions.filter((region) => successfulRegionSet.has(region));
+  const complete = succeeded.length === requests.length;
 
-  res.setHeader("Cache-Control", "s-maxage=600, stale-while-revalidate");
+  res.setHeader(
+    "Cache-Control",
+    complete ? "s-maxage=600, stale-while-revalidate" : "s-maxage=300, stale-while-revalidate"
+  );
   return res.status(200).json({ results, regionsUsed });
 }

--- a/pages/api/tmdb/providers-list.ts
+++ b/pages/api/tmdb/providers-list.ts
@@ -3,6 +3,31 @@ import { mergeProviderCatalog, parseRegions, type TmdbProviderResponse } from "@
 
 const API_BASE = "https://api.themoviedb.org/3";
 
+type ProviderSource = {
+  ok: boolean;
+  payload: TmdbProviderResponse;
+};
+
+async function fetchProviderSource(url: string): Promise<ProviderSource> {
+  try {
+    const response = await fetch(url);
+    if (!response.ok) return { ok: false, payload: {} };
+
+    const payload: unknown = await response.json();
+    if (
+      typeof payload !== "object" ||
+      payload === null ||
+      !Array.isArray((payload as TmdbProviderResponse).results)
+    ) {
+      return { ok: false, payload: {} };
+    }
+
+    return { ok: true, payload: payload as TmdbProviderResponse };
+  } catch {
+    return { ok: false, payload: {} };
+  }
+}
+
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== "GET") {
     return res.status(405).json({ error: "Method not allowed" });
@@ -23,27 +48,27 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   }
 
   try {
-    const [movieRes, tvRes] = await Promise.all([
-      fetch(`${API_BASE}/watch/providers/movie?api_key=${apiKey}`),
-      fetch(`${API_BASE}/watch/providers/tv?api_key=${apiKey}`),
+    const sources = await Promise.all([
+      fetchProviderSource(`${API_BASE}/watch/providers/movie?api_key=${apiKey}`),
+      fetchProviderSource(`${API_BASE}/watch/providers/tv?api_key=${apiKey}`),
     ]);
+    const usable = sources.filter((source) => source.ok);
 
     // A partial outage still yields a usable catalog, so only fail when both die.
-    if (!movieRes.ok && !tvRes.ok) {
+    if (usable.length === 0) {
       return res.status(502).json({ error: "Failed to fetch provider catalog" });
     }
 
-    const payloads: TmdbProviderResponse[] = await Promise.all(
-      [movieRes, tvRes].map(async (response) => (response.ok ? await response.json() : {}))
+    const providers = mergeProviderCatalog(
+      usable.map((source) => source.payload),
+      regions
     );
-
-    const providers = mergeProviderCatalog(payloads, regions);
 
     // A complete catalogue changes rarely, so cache it for a day. A degraded one
     // is missing whichever providers were unique to the failed source, so cache
     // it briefly instead — otherwise a transient upstream blip hides services
     // from the picker for 24 hours with no way to bust it.
-    const complete = movieRes.ok && tvRes.ok;
+    const complete = usable.length === sources.length;
     res.setHeader(
       "Cache-Control",
       complete ? "s-maxage=86400, stale-while-revalidate" : "s-maxage=300, stale-while-revalidate"

--- a/pages/settings.tsx
+++ b/pages/settings.tsx
@@ -2,7 +2,7 @@ import { useEffect, useRef, useState } from "react";
 import { useRouter } from "next/router";
 import { useAuth } from "@/lib/AuthContext";
 import type { FavoriteService } from "@/lib/preferences";
-import { resolveHydrationAction } from "@/lib/preferences";
+import { canSavePreferences, resolveHydrationAction } from "@/lib/preferences";
 import fullCountryList from "@/lib/full_country_list_with_flags.json";
 import { Search, Check, Globe, LogOut, User, Home } from "lucide-react";
 import Link from "next/link";
@@ -24,7 +24,15 @@ declare global {
 }
 
 export default function SettingsPage() {
-  const { user, preferences, preferencesUid, updatePreferences, signOut } = useAuth();
+  const {
+    user,
+    preferences,
+    preferencesUid,
+    preferencesStatus,
+    updatePreferences,
+    refreshPreferences,
+    signOut,
+  } = useAuth();
   const [selected, setSelected] = useState<string[]>([]);
   const [selectedServices, setSelectedServices] = useState<FavoriteService[]>([]);
   const [groupedByContinent, setGroupedByContinent] = useState<Record<string, Country[]>>({});
@@ -32,6 +40,11 @@ export default function SettingsPage() {
   const [saving, setSaving] = useState(false);
   const [saveError, setSaveError] = useState<string | null>(null);
   const router = useRouter();
+  const preferencesReady = canSavePreferences({
+    userUid: user?.uid ?? null,
+    preferencesUid,
+    status: preferencesStatus,
+  });
 
   // Hydrate the editable copy from preferences once per signed-in user. A later
   // refresh of `preferences` (another tab, a background reload) must not
@@ -162,7 +175,7 @@ export default function SettingsPage() {
   // failure so nothing the user picked is lost, and the error is rendered
   // inline rather than swallowed.
   const handleSave = async () => {
-    if (!user) return;
+    if (!user || !preferencesReady) return;
     setSaving(true);
     setSaveError(null);
     try {
@@ -361,6 +374,39 @@ export default function SettingsPage() {
       {/* Save Button */}
       {user && (
         <div className="sticky bottom-20 pt-4 pb-2" style={{ background: "var(--background)" }}>
+          {preferencesStatus === "loading" && (
+            <p
+              role="status"
+              className="max-w-md mx-auto mb-3 text-sm rounded-xl px-4 py-3"
+              style={{
+                background: "var(--card)",
+                border: "1px solid var(--border)",
+                color: "var(--foreground)",
+              }}
+            >
+              Loading your saved preferences…
+            </p>
+          )}
+          {preferencesStatus === "error" && (
+            <div
+              role="alert"
+              className="max-w-md mx-auto mb-3 text-sm rounded-xl px-4 py-3"
+              style={{
+                background: "var(--card)",
+                border: "1px solid var(--border)",
+                color: "var(--foreground)",
+              }}
+            >
+              <p>Could not load your saved preferences. Saving is disabled to protect them.</p>
+              <button
+                type="button"
+                onClick={() => void refreshPreferences()}
+                className="mt-2 font-semibold underline"
+              >
+                Retry loading
+              </button>
+            </div>
+          )}
           {saveError && (
             <p
               role="alert"
@@ -376,12 +422,16 @@ export default function SettingsPage() {
           )}
           <button
             onClick={handleSave}
-            disabled={saving}
+            disabled={saving || !preferencesReady}
             className="btn-primary w-full max-w-md mx-auto block"
           >
             {saving
               ? "Saving..."
-              : `Save Preferences (${selected.length} countries, ${selectedServices.length} services)`}
+              : preferencesStatus === "loading"
+                ? "Loading preferences..."
+                : preferencesStatus === "error"
+                  ? "Preferences unavailable"
+                  : `Save Preferences (${selected.length} countries, ${selectedServices.length} services)`}
           </button>
         </div>
       )}

--- a/tests/discoverMerge.test.ts
+++ b/tests/discoverMerge.test.ts
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import {
   parseProviderIds,
   mergeDiscoverResults,
+  MAX_DISCOVER_PROVIDERS,
   MAX_DISCOVER_RESULTS,
   type DiscoverItem,
 } from "../lib/discoverMerge";
@@ -32,8 +33,8 @@ describe("parseProviderIds", () => {
     assert.deepEqual(parseProviderIds("8"), [8]);
   });
 
-  test("dedupes and preserves first-seen order", () => {
-    assert.deepEqual(parseProviderIds("8|337|8"), [8, 337]);
+  test("dedupes and sorts into canonical order", () => {
+    assert.deepEqual(parseProviderIds("337|8|337"), [8, 337]);
   });
 
   test("rejects non-numeric, negative, and malformed input", () => {
@@ -41,12 +42,22 @@ describe("parseProviderIds", () => {
     assert.equal(parseProviderIds("-8"), null);
     assert.equal(parseProviderIds("8.5"), null);
     assert.equal(parseProviderIds("8||337"), null);
+    assert.equal(parseProviderIds("0"), null);
   });
 
   test("rejects absent, empty, or non-string input", () => {
     assert.equal(parseProviderIds(undefined), null);
     assert.equal(parseProviderIds(""), null);
     assert.equal(parseProviderIds(["8"]), null);
+  });
+
+  test("rejects provider sets above the public route limit", () => {
+    const tooMany = Array.from(
+      { length: MAX_DISCOVER_PROVIDERS + 1 },
+      (_, index) => index + 1
+    ).join("|");
+
+    assert.equal(parseProviderIds(tooMany), null);
   });
 });
 

--- a/tests/tmdbRoutes.test.ts
+++ b/tests/tmdbRoutes.test.ts
@@ -1,0 +1,172 @@
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+import discoverHandler from "../pages/api/tmdb/discover";
+import providersListHandler from "../pages/api/tmdb/providers-list";
+
+type MockResponse = {
+  statusCode: number;
+  body: any;
+  headers: Record<string, string | number | readonly string[]>;
+  status: (code: number) => MockResponse;
+  json: (body: unknown) => MockResponse;
+  setHeader: (name: string, value: string | number | readonly string[]) => void;
+};
+
+function createResponse(): MockResponse {
+  return {
+    statusCode: 200,
+    body: undefined,
+    headers: {},
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(body) {
+      this.body = body;
+      return this;
+    },
+    setHeader(name, value) {
+      this.headers[name] = value;
+    },
+  };
+}
+
+function response(body: unknown, options: { ok?: boolean; status?: number } = {}): Response {
+  return {
+    ok: options.ok ?? true,
+    status: options.status ?? 200,
+    json: async () => body,
+  } as Response;
+}
+
+function installFetch(
+  t: { after: (callback: () => void) => void },
+  implementation: typeof fetch
+) {
+  const originalFetch = globalThis.fetch;
+  const originalApiKey = process.env.TMDB_API_KEY;
+  globalThis.fetch = implementation;
+  process.env.TMDB_API_KEY = "test-key";
+  t.after(() => {
+    globalThis.fetch = originalFetch;
+    if (originalApiKey === undefined) delete process.env.TMDB_API_KEY;
+    else process.env.TMDB_API_KEY = originalApiKey;
+  });
+}
+
+describe("providers-list route", () => {
+  test("returns the usable source with a short cache when the other request rejects", async (t) => {
+    installFetch(t, (async (input) => {
+      const url = String(input);
+      if (url.includes("/movie")) throw new Error("network unavailable");
+      return response({
+        results: [
+          {
+            provider_id: 8,
+            provider_name: "Netflix",
+            logo_path: "/n.jpg",
+            display_priorities: { US: 1 },
+          },
+        ],
+      });
+    }) as typeof fetch);
+
+    const res = createResponse();
+    await providersListHandler(
+      { method: "GET", query: { regions: "US" } } as any,
+      res as any
+    );
+
+    assert.equal(res.statusCode, 200);
+    assert.deepEqual(res.body.providers.map((provider: any) => provider.id), [8]);
+    assert.equal(res.headers["Cache-Control"], "s-maxage=300, stale-while-revalidate");
+  });
+
+  test("does not let malformed JSON from one source mask the valid source", async (t) => {
+    installFetch(t, (async (input) => {
+      const url = String(input);
+      if (url.includes("/movie")) return response({ unexpected: true });
+      return response({ results: [] });
+    }) as typeof fetch);
+
+    const res = createResponse();
+    await providersListHandler(
+      { method: "GET", query: { regions: "US" } } as any,
+      res as any
+    );
+
+    assert.equal(res.statusCode, 200);
+    assert.deepEqual(res.body.providers, []);
+    assert.equal(res.headers["Cache-Control"], "s-maxage=300, stale-while-revalidate");
+  });
+
+  test("returns 502 only when neither source is usable", async (t) => {
+    installFetch(t, (async () => {
+      throw new Error("network unavailable");
+    }) as typeof fetch);
+
+    const res = createResponse();
+    await providersListHandler(
+      { method: "GET", query: { regions: "US" } } as any,
+      res as any
+    );
+
+    assert.equal(res.statusCode, 502);
+  });
+});
+
+describe("discover route", () => {
+  test("reports only successful regions and briefly caches degraded results", async (t) => {
+    installFetch(t, (async (input) => {
+      const url = new URL(String(input));
+      const region = url.searchParams.get("watch_region");
+      if (region === "US") throw new Error("region unavailable");
+      if (url.pathname.endsWith("/tv")) return response({}, { ok: false, status: 503 });
+      return response({
+        results: [{ id: 10, title: "Available", poster_path: null, popularity: 9 }],
+      });
+    }) as typeof fetch);
+
+    const res = createResponse();
+    await discoverHandler(
+      { method: "GET", query: { regions: "US,GB", providers: "8|337" } } as any,
+      res as any
+    );
+
+    assert.equal(res.statusCode, 200);
+    assert.deepEqual(res.body.regionsUsed, ["GB"]);
+    assert.deepEqual(res.body.results.map((item: any) => item.id), [10]);
+    assert.equal(res.headers["Cache-Control"], "s-maxage=300, stale-while-revalidate");
+  });
+
+  test("uses the full cache only when every upstream request succeeds", async (t) => {
+    installFetch(t, (async () => response({ results: [] })) as typeof fetch);
+
+    const res = createResponse();
+    await discoverHandler(
+      { method: "GET", query: { regions: "US,GB", providers: "8|337" } } as any,
+      res as any
+    );
+
+    assert.equal(res.statusCode, 200);
+    assert.deepEqual(res.body.regionsUsed, ["US", "GB"]);
+    assert.equal(res.headers["Cache-Control"], "s-maxage=600, stale-while-revalidate");
+  });
+
+  test("rejects noncanonical provider permutations before making upstream requests", async (t) => {
+    let fetchCalls = 0;
+    installFetch(t, (async () => {
+      fetchCalls += 1;
+      return response({ results: [] });
+    }) as typeof fetch);
+
+    const res = createResponse();
+    await discoverHandler(
+      { method: "GET", query: { regions: "US", providers: "337|8|337" } } as any,
+      res as any
+    );
+
+    assert.equal(res.statusCode, 400);
+    assert.equal(fetchCalls, 0);
+  });
+});

--- a/tests/userPreferences.test.ts
+++ b/tests/userPreferences.test.ts
@@ -2,12 +2,14 @@ import { test, describe } from "node:test";
 import assert from "node:assert/strict";
 import {
   buildDiscoverQuery,
+  canSavePreferences,
   normalizePreferences,
   removeFavoriteService,
   resolveActiveCountry,
   resolveHydrationAction,
   toggleFavoriteService,
 } from "../lib/preferences";
+import { MAX_DISCOVER_PROVIDERS } from "../lib/discoverMerge";
 
 describe("normalizePreferences", () => {
   test("defaults favoriteServices to an empty array when absent", () => {
@@ -79,6 +81,20 @@ describe("normalizePreferences", () => {
     });
 
     assert.deepEqual(prefs.favoriteServices, []);
+  });
+
+  test("drops non-positive, fractional, and unsafe ids while keeping valid entries", () => {
+    const prefs = normalizePreferences({
+      favoriteServices: [
+        { id: -8, name: "Negative" },
+        { id: 0, name: "Zero" },
+        { id: 8.5, name: "Fractional" },
+        { id: Number.MAX_SAFE_INTEGER + 1, name: "Unsafe" },
+        { id: 8, name: "Netflix", logoPath: "/n.jpg" },
+      ],
+    });
+
+    assert.deepEqual(prefs.favoriteServices, [NETFLIX]);
   });
 });
 
@@ -175,6 +191,27 @@ describe("buildDiscoverQuery", () => {
     assert.equal(query, "/api/tmdb/discover?regions=US%2CGB&providers=8%7C337");
   });
 
+  test("sorts and dedupes provider ids for one canonical cache key", () => {
+    const query = buildDiscoverQuery(SIGNED_IN_USER, {
+      favoriteCountries: ["US"],
+      favoriteServices: [DISNEY, NETFLIX, { ...NETFLIX, name: "Duplicate" }],
+    });
+
+    assert.equal(query, "/api/tmdb/discover?regions=US&providers=8%7C337");
+  });
+
+  test("does not build a request above the provider limit", () => {
+    const favoriteServices = Array.from(
+      { length: MAX_DISCOVER_PROVIDERS + 1 },
+      (_, index) => ({ id: index + 1, name: `Provider ${index + 1}`, logoPath: "" })
+    );
+
+    assert.equal(
+      buildDiscoverQuery(SIGNED_IN_USER, { favoriteCountries: ["US"], favoriteServices }),
+      null
+    );
+  });
+
   test("encodes a country value containing an ampersand rather than letting it mangle the query string", () => {
     const query = buildDiscoverQuery(SIGNED_IN_USER, {
       favoriteCountries: ["US&evil=1"],
@@ -192,6 +229,27 @@ describe("buildDiscoverQuery", () => {
     });
 
     assert.equal(query, `/api/tmdb/discover?regions=${encodeURIComponent(manyCountries.join(","))}&providers=8`);
+  });
+});
+
+describe("canSavePreferences", () => {
+  test("only enables persistence for successfully loaded preferences owned by the current user", () => {
+    assert.equal(
+      canSavePreferences({ userUid: "user-a", preferencesUid: "user-a", status: "ready" }),
+      true
+    );
+    assert.equal(
+      canSavePreferences({ userUid: "user-a", preferencesUid: null, status: "loading" }),
+      false
+    );
+    assert.equal(
+      canSavePreferences({ userUid: "user-a", preferencesUid: null, status: "error" }),
+      false
+    );
+    assert.equal(
+      canSavePreferences({ userUid: "user-a", preferencesUid: "user-b", status: "ready" }),
+      false
+    );
   });
 });
 


### PR DESCRIPTION
Addresses all five findings from the latest review of PR #34:

- isolate provider-catalog fetch and JSON failures so partial data remains usable (#36)
- report only successful discover regions and use a short degraded cache (#37)
- cap and canonicalize provider IDs before public TMDB fan-out (#38)
- reject invalid stored provider IDs during preference normalization (#39)
- disable settings persistence until the current user preference read succeeds (#41)

Validation:
- npm test: 115 passing
- tsc --noEmit: passing
- next build: application compilation passes; page-data collection requires configured Firebase credentials