### PR TITLE
Fix remaining PR #34 cache and theme races

### DIFF
--- a/lib/AuthContext.tsx
+++ b/lib/AuthContext.tsx
@@ -2,7 +2,8 @@ import { createContext, useContext, useEffect, useRef, useState, ReactNode } fro
 import { User, onAuthStateChanged, signOut as firebaseSignOut } from "firebase/auth";
 import { auth } from "./firebase";
 import { loadUserPreferences, saveUserPreferences } from "./firestore";
-import type { PreferencesLoadStatus, UserPreferences } from "./preferences";
+import { reconcilePreferencesWithThemeSelection } from "./preferences";
+import type { PreferencesLoadStatus, ThemeSelection, UserPreferences } from "./preferences";
 
 interface AuthContextType {
   user: User | null;
@@ -32,6 +33,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   // resolve their loads out of order, so a load only publishes if its own uid is
   // still the current one.
   const latestUid = useRef<string | null>(null);
+  const themeRevision = useRef(0);
+  const latestThemeSelection = useRef<ThemeSelection | null>(null);
 
   // Apply theme based on darkMode preference (dark is default, light when darkMode is false)
   const applyTheme = (darkMode: boolean) => {
@@ -50,7 +53,9 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     }
 
     const unsubscribe = onAuthStateChanged(auth, async (firebaseUser) => {
-      latestUid.current = firebaseUser?.uid ?? null;
+      const nextUid = firebaseUser?.uid ?? null;
+      if (latestUid.current !== nextUid) latestThemeSelection.current = null;
+      latestUid.current = nextUid;
       setUser(firebaseUser);
 
       // Drop the outgoing identity's preferences before awaiting the next
@@ -61,11 +66,19 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       if (firebaseUser) {
         setPreferencesStatus("loading");
         try {
-          const prefs = await loadUserPreferences(firebaseUser.uid);
+          const loadStartedAtThemeRevision = themeRevision.current;
+          const loadedPreferences = await loadUserPreferences(firebaseUser.uid);
 
           // A newer auth event landed while this load was in flight — its result
           // is the current one, so discard ours rather than clobbering it.
           if (latestUid.current !== firebaseUser.uid) return;
+
+          const prefs = reconcilePreferencesWithThemeSelection(
+            loadedPreferences,
+            firebaseUser.uid,
+            loadStartedAtThemeRevision,
+            latestThemeSelection.current
+          );
 
           setPreferences(prefs);
           setPreferencesUid(firebaseUser.uid);
@@ -99,6 +112,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     await firebaseSignOut(auth);
     localStorage.removeItem("user");
     latestUid.current = null;
+    latestThemeSelection.current = null;
     setUser(null);
     setPreferences(null);
     setPreferencesUid(null);
@@ -108,6 +122,12 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const updatePreferences = async (prefs: Partial<UserPreferences>) => {
     // Save to localStorage for non-logged-in users
     if (prefs.darkMode !== undefined) {
+      themeRevision.current += 1;
+      latestThemeSelection.current = {
+        uid: user?.uid ?? null,
+        darkMode: prefs.darkMode,
+        revision: themeRevision.current,
+      };
       localStorage.setItem("darkMode", String(prefs.darkMode));
       applyTheme(prefs.darkMode);
     }
@@ -145,8 +165,15 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     if (!user) return;
     setPreferencesStatus("loading");
     try {
-      const prefs = await loadUserPreferences(user.uid);
+      const loadStartedAtThemeRevision = themeRevision.current;
+      const loadedPreferences = await loadUserPreferences(user.uid);
       if (latestUid.current !== user.uid) return;
+      const prefs = reconcilePreferencesWithThemeSelection(
+        loadedPreferences,
+        user.uid,
+        loadStartedAtThemeRevision,
+        latestThemeSelection.current
+      );
       setPreferences(prefs);
       setPreferencesUid(user.uid);
       setPreferencesStatus("ready");

--- a/lib/preferences.ts
+++ b/lib/preferences.ts
@@ -7,6 +7,7 @@
 // vars. Keeping this file free of Firebase lets it be unit tested standalone.
 
 import { MAX_DISCOVER_PROVIDERS } from "./discoverMerge";
+import { canonicalizeRegionSet } from "./providerCatalog";
 
 export type FavoriteService = {
   id: number;
@@ -21,6 +22,12 @@ export type UserPreferences = {
 };
 
 export type PreferencesLoadStatus = "idle" | "loading" | "ready" | "error";
+
+export type ThemeSelection = {
+  uid: string | null;
+  darkMode: boolean;
+  revision: number;
+};
 
 // Firestore documents are untrusted input: a partial write or an older client
 // can leave any field missing or the wrong shape. Normalizing in one place keeps
@@ -92,6 +99,26 @@ export function canSavePreferences(input: {
   );
 }
 
+// A Firestore read can start before a theme toggle and resolve after it. Only a
+// selection made after that read began may override its snapshot; older local
+// selections must not mask a genuinely newer server read.
+export function reconcilePreferencesWithThemeSelection(
+  preferences: UserPreferences,
+  userUid: string,
+  loadStartedAtThemeRevision: number,
+  selection: ThemeSelection | null
+): UserPreferences {
+  if (
+    !selection ||
+    selection.uid !== userUid ||
+    selection.revision <= loadStartedAtThemeRevision
+  ) {
+    return preferences;
+  }
+
+  return { ...preferences, darkMode: selection.darkMode };
+}
+
 // Selection helpers. ServicePicker is a controlled component, so the list of
 // chosen services lives in the parent page; keeping the transitions pure here
 // means they can be unit tested without rendering React.
@@ -134,13 +161,10 @@ function isFavoriteService(value: unknown): value is { id: number; name: string;
 // Firebase's `User` type, keeping this module dependency-free; a real
 // firebase/auth `User` satisfies this shape.
 //
-// `favoriteCountries` is only type-validated by normalizePreferences (entries
-// are guaranteed to be strings, but not to be real region codes), so a
-// malformed Firestore value containing "&" or "#" must not be allowed to
-// mangle the query string — hence
-// encodeURIComponent around the joined region/provider lists rather than
-// around each element (the delimiter itself needs to survive being embedded
-// in the query value and round-trip through Next's automatic query decoding).
+// `favoriteCountries` comes from an untrusted Firestore document, so validate
+// it with the API's parser and canonicalize its set before building the URL.
+// This keeps equivalent selections on one CDN cache key. encodeURIComponent
+// then ensures the delimiters round-trip through Next's query decoding.
 //
 // Does not cap the region count: pages/api/tmdb/discover.ts already caps at
 // MAX_DISCOVER_REGIONS server-side, so duplicating the cap here would just be
@@ -156,6 +180,9 @@ export function buildDiscoverQuery(
 
   if (countries.length === 0 || services.length === 0) return null;
 
+  const regionCodes = canonicalizeRegionSet(countries);
+  if (!regionCodes) return null;
+
   const providerIds = [...new Set(
     services
       .map((service) => service.id)
@@ -164,7 +191,7 @@ export function buildDiscoverQuery(
 
   if (providerIds.length === 0 || providerIds.length > MAX_DISCOVER_PROVIDERS) return null;
 
-  const regions = encodeURIComponent(countries.join(","));
+  const regions = encodeURIComponent(regionCodes.join(","));
   const providers = encodeURIComponent(providerIds.join("|"));
 
   return `/api/tmdb/discover?regions=${regions}&providers=${providers}`;

--- a/lib/providerCatalog.ts
+++ b/lib/providerCatalog.ts
@@ -41,6 +41,16 @@ export function parseRegions(raw: unknown): string[] | null {
   return [...new Set(parts.map((part) => part.toUpperCase()))];
 }
 
+/** Validates and returns one deterministic representation for a region set. */
+export function canonicalizeRegionSet(regions: string[]): string[] | null {
+  const normalized = regions.map((region) => region.trim());
+  if (normalized.length === 0 || !normalized.every((region) => ALPHA_2.test(region))) {
+    return null;
+  }
+
+  return [...new Set(normalized.map((region) => region.toUpperCase()))].sort();
+}
+
 /**
  * Merges the movie and TV provider catalogs into one deduped list, keeping only
  * providers offered in at least one requested region.

--- a/pages/api/tmdb/discover.ts
+++ b/pages/api/tmdb/discover.ts
@@ -1,5 +1,5 @@
 import type { NextApiRequest, NextApiResponse } from "next";
-import { parseRegions } from "@/lib/providerCatalog";
+import { canonicalizeRegionSet, parseRegions } from "@/lib/providerCatalog";
 import {
   MAX_DISCOVER_REGIONS,
   mergeDiscoverResults,
@@ -28,6 +28,17 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     });
   }
 
+  const canonicalRegions = canonicalizeRegionSet(allRegions);
+  if (!canonicalRegions) {
+    return res.status(400).json({ error: "Invalid regions" });
+  }
+  const regionParam = canonicalRegions.join(",");
+  if (req.query.regions !== regionParam) {
+    return res.status(400).json({
+      error: "regions must be sorted, unique uppercase ISO-3166-1 alpha-2 codes",
+    });
+  }
+
   if (!providers) {
     return res.status(400).json({
       error: "providers is required as a pipe-separated list of TMDB provider ids, e.g. providers=8|337",
@@ -53,7 +64,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
   // Bound the fan-out; the response reports what was actually queried so the UI
   // can be honest about coverage rather than implying it searched everywhere.
-  const requestedRegions = allRegions.slice(0, MAX_DISCOVER_REGIONS);
+  const requestedRegions = canonicalRegions.slice(0, MAX_DISCOVER_REGIONS);
 
   const requests = requestedRegions.flatMap((region) =>
     MEDIA_TYPES.map(async (mediaType): Promise<{ region: string; items: DiscoverItem[] }> => {

--- a/tests/tmdbRoutes.test.ts
+++ b/tests/tmdbRoutes.test.ts
@@ -129,7 +129,7 @@ describe("discover route", () => {
 
     const res = createResponse();
     await discoverHandler(
-      { method: "GET", query: { regions: "US,GB", providers: "8|337" } } as any,
+      { method: "GET", query: { regions: "GB,US", providers: "8|337" } } as any,
       res as any
     );
 
@@ -144,12 +144,12 @@ describe("discover route", () => {
 
     const res = createResponse();
     await discoverHandler(
-      { method: "GET", query: { regions: "US,GB", providers: "8|337" } } as any,
+      { method: "GET", query: { regions: "GB,US", providers: "8|337" } } as any,
       res as any
     );
 
     assert.equal(res.statusCode, 200);
-    assert.deepEqual(res.body.regionsUsed, ["US", "GB"]);
+    assert.deepEqual(res.body.regionsUsed, ["GB", "US"]);
     assert.equal(res.headers["Cache-Control"], "s-maxage=600, stale-while-revalidate");
   });
 
@@ -163,6 +163,23 @@ describe("discover route", () => {
     const res = createResponse();
     await discoverHandler(
       { method: "GET", query: { regions: "US", providers: "337|8|337" } } as any,
+      res as any
+    );
+
+    assert.equal(res.statusCode, 400);
+    assert.equal(fetchCalls, 0);
+  });
+
+  test("rejects noncanonical region permutations before making upstream requests", async (t) => {
+    let fetchCalls = 0;
+    installFetch(t, (async () => {
+      fetchCalls += 1;
+      return response({ results: [] });
+    }) as typeof fetch);
+
+    const res = createResponse();
+    await discoverHandler(
+      { method: "GET", query: { regions: "US,GB", providers: "8|337" } } as any,
       res as any
     );
 

--- a/tests/userPreferences.test.ts
+++ b/tests/userPreferences.test.ts
@@ -5,6 +5,7 @@ import {
   canSavePreferences,
   normalizePreferences,
   removeFavoriteService,
+  reconcilePreferencesWithThemeSelection,
   resolveActiveCountry,
   resolveHydrationAction,
   toggleFavoriteService,
@@ -188,7 +189,16 @@ describe("buildDiscoverQuery", () => {
       favoriteServices: [NETFLIX, DISNEY],
     });
 
-    assert.equal(query, "/api/tmdb/discover?regions=US%2CGB&providers=8%7C337");
+    assert.equal(query, "/api/tmdb/discover?regions=GB%2CUS&providers=8%7C337");
+  });
+
+  test("sorts and dedupes regions for one canonical cache key", () => {
+    const query = buildDiscoverQuery(SIGNED_IN_USER, {
+      favoriteCountries: ["us", "GB", "US"],
+      favoriteServices: [NETFLIX],
+    });
+
+    assert.equal(query, "/api/tmdb/discover?regions=GB%2CUS&providers=8");
   });
 
   test("sorts and dedupes provider ids for one canonical cache key", () => {
@@ -212,13 +222,22 @@ describe("buildDiscoverQuery", () => {
     );
   });
 
-  test("encodes a country value containing an ampersand rather than letting it mangle the query string", () => {
+  test("rejects a malformed country value rather than putting it in the query string", () => {
     const query = buildDiscoverQuery(SIGNED_IN_USER, {
       favoriteCountries: ["US&evil=1"],
       favoriteServices: [NETFLIX],
     });
 
-    assert.equal(query, "/api/tmdb/discover?regions=US%26evil%3D1&providers=8");
+    assert.equal(query, null);
+  });
+
+  test("rejects a stored value that tries to smuggle multiple region codes", () => {
+    const query = buildDiscoverQuery(SIGNED_IN_USER, {
+      favoriteCountries: ["US,GB"],
+      favoriteServices: [NETFLIX],
+    });
+
+    assert.equal(query, null);
   });
 
   test("does not cap the region count client-side (the discover API caps server-side)", () => {
@@ -228,7 +247,46 @@ describe("buildDiscoverQuery", () => {
       favoriteServices: [NETFLIX],
     });
 
-    assert.equal(query, `/api/tmdb/discover?regions=${encodeURIComponent(manyCountries.join(","))}&providers=8`);
+    assert.equal(
+      query,
+      `/api/tmdb/discover?regions=${encodeURIComponent([...manyCountries].sort().join(","))}&providers=8`
+    );
+  });
+});
+
+describe("reconcilePreferencesWithThemeSelection", () => {
+  const loaded = normalizePreferences({ darkMode: true });
+
+  test("keeps a theme toggle made while the read was in flight", () => {
+    const reconciled = reconcilePreferencesWithThemeSelection(
+      loaded,
+      "user-a",
+      4,
+      { uid: "user-a", darkMode: false, revision: 5 }
+    );
+
+    assert.equal(reconciled.darkMode, false);
+  });
+
+  test("does not let an older or different user's selection mask the loaded value", () => {
+    assert.equal(
+      reconcilePreferencesWithThemeSelection(
+        loaded,
+        "user-a",
+        5,
+        { uid: "user-a", darkMode: false, revision: 5 }
+      ).darkMode,
+      true
+    );
+    assert.equal(
+      reconcilePreferencesWithThemeSelection(
+        loaded,
+        "user-a",
+        4,
+        { uid: "user-b", darkMode: false, revision: 5 }
+      ).darkMode,
+      true
+    );
   });
 });
 


### PR DESCRIPTION
Addresses the two follow-up findings on PR #34:

- canonicalizes region sets on the client and rejects noncanonical region permutations before TMDB fan-out, completing #38
- reconciles same-user theme selections made after a preference read starts, so a stale read cannot visibly undo the toggle, completing the #41 follow-up

Validation:
- npm test: 120 passing
- tsc --noEmit: passing
- next build: application compilation passes; page-data collection requires configured Firebase credentials